### PR TITLE
[fix] Controlify tab safety, Iris state sync, and native-screen return behavior

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.jvmargs=-Xmx3G
 org.gradle.workers.max=1
 
 # Mod Information
-mod.version=3.4.0
+mod.version=3.4.1
 mod.name=xanders-sodium-options
 
 # Dependencies

--- a/src/main/java/dev/isxander/xso/XandersSodiumOptions.java
+++ b/src/main/java/dev/isxander/xso/XandersSodiumOptions.java
@@ -19,6 +19,7 @@ import net.caffeinemc.mods.sodium.client.config.structure.OptionPage;
 import net.caffeinemc.mods.sodium.client.config.structure.Page;
 import net.caffeinemc.mods.sodium.client.config.structure.StatefulOption;
 import net.caffeinemc.mods.sodium.client.gui.VideoSettingsScreen;
+import net.irisshaders.iris.Iris;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.screens.AlertScreen;
@@ -34,11 +35,17 @@ import org.slf4j.LoggerFactory;
 public class XandersSodiumOptions {
     private static boolean errorOccurred = false;
     private static final String SODIUM_CONFIG_ID = "sodium";
+    private static final Identifier IMPROVED_TRANSPARENCY_OPTION_ID =
+            Identifier.fromNamespaceAndPath("sodium", "quality.graphics");
     public static final Logger LOGGER = LoggerFactory.getLogger("xanders-sodium-options");
+    @Nullable
+    private static dev.isxander.yacl3.api.Option<?> improvedTransparencyOption;
 
     public static Screen wrapSodiumScreen(
             VideoSettingsScreen videoSettingsScreen, List<ModOptions> modOptionsList, Screen prevScreen) {
         try {
+            improvedTransparencyOption = null;
+
             YetAnotherConfigLib.Builder builder =
                     YetAnotherConfigLib.createBuilder().title(Component.translatable("options.videoTitle"));
 
@@ -96,6 +103,10 @@ public class XandersSodiumOptions {
 
             for (ConfigCategory category : categories) {
                 builder.category(category);
+            }
+
+            if (Compat.IRIS.isLoaded) {
+                onIrisShaderTogglePending(Iris.getIrisConfig().areShadersEnabled());
             }
 
             builder.save(() -> {
@@ -367,6 +378,9 @@ public class XandersSodiumOptions {
             var id = ((SodiumOptionAccessor) entry.getValue()).getId();
             if (id != null) {
                 byId.put(id, entry);
+                if (IMPROVED_TRANSPARENCY_OPTION_ID.equals(id)) {
+                    improvedTransparencyOption = entry.getKey();
+                }
             }
         }
 
@@ -401,5 +415,11 @@ public class XandersSodiumOptions {
 
     public static boolean shouldConvertGui() {
         return XsoConfig.INSTANCE.instance().enabled && !errorOccurred;
+    }
+
+    public static void onIrisShaderTogglePending(boolean shadersEnabled) {
+        if (improvedTransparencyOption != null) {
+            improvedTransparencyOption.setAvailable(!shadersEnabled);
+        }
     }
 }

--- a/src/main/java/dev/isxander/xso/compat/IrisCompat.java
+++ b/src/main/java/dev/isxander/xso/compat/IrisCompat.java
@@ -3,6 +3,7 @@ package dev.isxander.xso.compat;
 import dev.isxander.xso.XandersSodiumOptions;
 import dev.isxander.xso.config.XsoConfig;
 import dev.isxander.yacl3.api.*;
+import dev.isxander.yacl3.gui.YACLScreen;
 import dev.isxander.yacl3.api.controller.BooleanControllerBuilder;
 import dev.isxander.yacl3.impl.controller.DropdownStringControllerBuilderImpl;
 import java.io.IOException;
@@ -27,19 +28,37 @@ import net.fabricmc.loader.api.FabricLoader;
 public class IrisCompat {
     private static boolean dirty = false;
 
+    private static Screen createWrappedReturnScreen(Screen prevScreen, VideoSettingsScreen videoSettingsScreen) {
+        return new Screen(Component.empty()) {
+            @Override
+            protected void init() {
+                minecraft.setScreen(XandersSodiumOptions.wrapSodiumScreen(
+                        videoSettingsScreen, ConfigManager.CONFIG.getModOptions(), prevScreen));
+
+                minecraft.execute(() -> {
+                    if (minecraft.screen instanceof YACLScreen yaclScreen) {
+                        var tabs = yaclScreen.tabNavigationBar.getTabs();
+                        String irisTabTitle =
+                                Component.translatable("options.iris.shaderPackSelection.title").getString();
+                        for (int i = 0; i < tabs.size(); i++) {
+                            if (tabs.get(i).getTabTitle().getString().equals(irisTabTitle)) {
+                                yaclScreen.tabNavigationBar.selectTab(i, false);
+                                break;
+                            }
+                        }
+                    }
+                });
+            }
+        };
+    }
+
     public static ConfigCategory createShaderPacksCategory(Screen prevScreen, VideoSettingsScreen videoSettingsScreen) {
         if (XsoConfig.INSTANCE.instance().externalMenus) {
             return PlaceholderCategory.createBuilder()
                     .name(Component.translatable("options.iris.shaderPackSelection.title"))
                     .screen((client, screen) -> {
                         try {
-                            return new ShaderPackScreen(new Screen(Component.empty()) {
-                                @Override
-                                protected void init() {
-                                    minecraft.setScreen(XandersSodiumOptions.wrapSodiumScreen(
-                                            videoSettingsScreen, ConfigManager.CONFIG.getModOptions(), prevScreen));
-                                }
-                            });
+                            return new ShaderPackScreen(createWrappedReturnScreen(prevScreen, videoSettingsScreen));
                         } catch (Exception e) {
                             XandersSodiumOptions.LOGGER.error("Failed to open Iris settings screen", e);
 
@@ -103,7 +122,9 @@ public class IrisCompat {
                         .text(Component.literal("➔"))
                         .description(OptionDescription.of(
                                 Component.translatable("options.iris.openShaderPackScreen.description")))
-                        .action((screen, opt) -> Minecraft.getInstance().setScreen(new ShaderPackScreen(screen)))
+                        .action((screen, opt) -> Minecraft.getInstance()
+                                .setScreen(new ShaderPackScreen(
+                                        createWrappedReturnScreen(prevScreen, videoSettingsScreen))))
                         .build())
                 .option(ButtonOption.createBuilder()
                         .name(Component.translatable("options.iris.downloadShaders"))

--- a/src/main/java/dev/isxander/xso/compat/IrisCompat.java
+++ b/src/main/java/dev/isxander/xso/compat/IrisCompat.java
@@ -86,7 +86,9 @@ public class IrisCompat {
                 })
                 .addListener((option, event) -> {
                     if (event == OptionEventListener.Event.STATE_CHANGE) {
-                        shaderPackList.setAvailable(option.pendingValue());
+                        boolean shadersEnabled = option.pendingValue();
+                        shaderPackList.setAvailable(shadersEnabled);
+                        XandersSodiumOptions.onIrisShaderTogglePending(shadersEnabled);
                     }
                 })
                 .controller((opt) ->

--- a/src/main/java/dev/isxander/xso/mixins/TabManagerMixin.java
+++ b/src/main/java/dev/isxander/xso/mixins/TabManagerMixin.java
@@ -1,6 +1,8 @@
 package dev.isxander.xso.mixins;
 
+import dev.isxander.xso.utils.XsoTabNavigationScope;
 import dev.isxander.yacl3.gui.YACLScreen;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.components.tabs.Tab;
 import net.minecraft.client.gui.components.tabs.TabManager;
 import org.spongepowered.asm.mixin.Mixin;
@@ -15,6 +17,10 @@ public class TabManagerMixin {
     private void onTabChanged(Tab tab, boolean clickSound, CallbackInfo ci) {
         if (tab instanceof YACLScreen.CategoryTab categoryTab) {
             categoryTab.updateButtons();
+        }
+
+        if (Minecraft.getInstance().screen instanceof XsoTabNavigationScope scoped) {
+            scoped.xso$onTabChanged();
         }
     }
 }

--- a/src/main/java/dev/isxander/xso/mixins/yacl/OptionEntryMixin.java
+++ b/src/main/java/dev/isxander/xso/mixins/yacl/OptionEntryMixin.java
@@ -8,7 +8,10 @@ import dev.isxander.yacl3.gui.OptionListWidget;
 import dev.isxander.yacl3.gui.TextScaledButtonWidget;
 import dev.isxander.yacl3.gui.utils.WidgetUtils;
 import java.util.List;
+import net.minecraft.client.gui.ComponentPath;
 import net.minecraft.client.gui.components.events.GuiEventListener;
+import net.minecraft.client.gui.navigation.FocusNavigationEvent;
+import org.jspecify.annotations.NonNull;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -19,6 +22,22 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(value = OptionListWidget.OptionEntry.class, remap = false)
 public class OptionEntryMixin {
+    @Unique
+    private static final GuiEventListener xso$NON_FOCUSABLE_SPACER = new GuiEventListener() {
+        @Override
+        public void setFocused(boolean focused) {}
+
+        @Override
+        public boolean isFocused() {
+            return false;
+        }
+
+        @Override
+        public ComponentPath nextFocusPath(@NonNull FocusNavigationEvent event) {
+            return null;
+        }
+    };
+
     @Shadow
     @Final
     public Option<?> option;
@@ -45,7 +64,7 @@ public class OptionEntryMixin {
     @Inject(method = "children", at = @At("HEAD"), cancellable = true)
     private void xso$skipSpacerFromTabFocus(CallbackInfoReturnable<List<? extends GuiEventListener>> cir) {
         if (xso$isEmptySpacerOption()) {
-            cir.setReturnValue(ImmutableList.of());
+            cir.setReturnValue(ImmutableList.of(xso$NON_FOCUSABLE_SPACER));
         }
     }
 

--- a/src/main/java/dev/isxander/xso/mixins/yacl/YACLScreenMixin.java
+++ b/src/main/java/dev/isxander/xso/mixins/yacl/YACLScreenMixin.java
@@ -2,11 +2,13 @@ package dev.isxander.xso.mixins.yacl;
 
 import dev.isxander.xso.utils.XsoDonationButton;
 import dev.isxander.xso.utils.XsoDonationScope;
+import dev.isxander.xso.utils.XsoTabNavigationScope;
 import dev.isxander.yacl3.gui.YACLScreen;
 import java.util.List;
 import net.minecraft.client.gui.components.Button;
 import net.minecraft.client.gui.components.EditBox;
 import net.minecraft.client.gui.components.TabButton;
+import net.minecraft.client.gui.components.events.GuiEventListener;
 import net.minecraft.client.gui.components.tabs.Tab;
 import net.minecraft.client.gui.components.tabs.TabManager;
 import net.minecraft.client.gui.screens.Screen;
@@ -23,7 +25,7 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(value = YACLScreen.class)
-public abstract class YACLScreenMixin extends Screen implements XsoDonationScope {
+public abstract class YACLScreenMixin extends Screen implements XsoDonationScope, XsoTabNavigationScope {
     @Final
     @Shadow
     public TabManager tabManager;
@@ -37,6 +39,10 @@ public abstract class YACLScreenMixin extends Screen implements XsoDonationScope
     private boolean xso$donationScoped;
     @Unique
     private int xso$discardEscGraceTicks;
+    @Unique
+    private boolean xso$handlingTabChanged;
+    @Unique
+    private boolean xso$pendingTabHighlightSync;
 
     protected YACLScreenMixin(Component title) {
         super(title);
@@ -104,6 +110,15 @@ public abstract class YACLScreenMixin extends Screen implements XsoDonationScope
         this.xso$donationButton.active = isFirstTab;
     }
 
+    @Inject(method = "tick", at = @At("TAIL"))
+    private void xso$syncSelectedTabHighlight(CallbackInfo ci) {
+        if (!this.xso$pendingTabHighlightSync) return;
+        if (this.tabNavigationBar == null) return;
+
+        this.xso$focusSelectedTabButton();
+        this.xso$pendingTabHighlightSync = false;
+    }
+
     @Override
     public boolean keyPressed(@NonNull KeyEvent keyEvent) {
         if (this.tabNavigationBar != null
@@ -152,6 +167,35 @@ public abstract class YACLScreenMixin extends Screen implements XsoDonationScope
         } else if (right > visibleRight) {
             this.tabNavigationBar.setScrollOffset(
                     this.tabNavigationBar.getScrollOffset() + (right - visibleRight));
+        }
+    }
+
+    @Unique
+    private void xso$focusSelectedTabButton() {
+        if (this.tabNavigationBar == null) return;
+
+        int selectedIndex = this.tabNavigationBar.getTabs().indexOf(this.tabManager.getCurrentTab());
+        if (selectedIndex < 0) return;
+
+        List<? extends GuiEventListener> children = this.tabNavigationBar.children();
+        if (selectedIndex >= children.size()) return;
+
+        for (int i = 0; i < children.size(); i++) {
+            children.get(i).setFocused(i == selectedIndex);
+        }
+        this.setFocused(this.tabNavigationBar);
+    }
+
+    @Override
+    public void xso$onTabChanged() {
+        if (this.xso$handlingTabChanged) return;
+
+        this.xso$handlingTabChanged = true;
+        try {
+            this.xso$ensureSelectedTabVisible();
+            this.xso$pendingTabHighlightSync = true;
+        } finally {
+            this.xso$handlingTabChanged = false;
         }
     }
 

--- a/src/main/java/dev/isxander/xso/utils/XsoTabNavigationScope.java
+++ b/src/main/java/dev/isxander/xso/utils/XsoTabNavigationScope.java
@@ -1,0 +1,5 @@
+package dev.isxander.xso.utils;
+
+public interface XsoTabNavigationScope {
+    void xso$onTabChanged();
+}


### PR DESCRIPTION
## What does this PR do?

Fixes controller/tab-navigation stability issues in XSO's YACL Video Settings flow, restores reliable tab highlighting with Controlify, and improves Iris integration so shader-related option state and tab context stay correct when moving between XSO and Iris's native screen.

## Why is this change needed?

Recent behavior regressions caused crashes and inconsistent UI state in common controller + Iris workflows. Controlify tab switching could crash due to empty focus children, tab highlight/focus behavior was inconsistent on shoulder-button navigation, and returning from Iris's native shader screen did not reliably refresh XSO's Iris state or preserve the Iris tab context.

Additionally, Improved Transparency lock state did not update live when shaders changed unless the menu/session was rebuilt.

## Changes Made

- **Controlify Crash Fix**: Reworked spacer-focus handling so spacer rows no longer return an empty `children()` list, preventing `ArrayIndexOutOfBoundsException` during controller tab navigation.
- **Controller Tab Highlight Sync**: Added tab-change synchronization hooks so shoulder-button tab changes keep the selected tab visible and focused in the navigation bar.
- **Re-entrancy/Recursion Guard**: Added tab-change handling guards to prevent recursive tab-focus loops and `StackOverflowError`.
- **Improved Transparency Live Lock Sync**: Added targeted Iris shader-toggle sync for the Sodium Improved Transparency option (`sodium:quality.graphics`) so lock/unlock updates immediately in-session.
- **Initial Iris-State Sync on Screen Build**: Applied Iris shader-state sync during XSO screen creation so reopening Video Settings reflects current lock state without requiring an extra toggle.
- **Native Iris Return Refresh**: Updated "Open Original Screen" return flow to rebuild XSO after closing Iris native screen so enabled state and selected shader pack are refreshed immediately.
- **Return-to-Iris-Tab Behavior**: After rebuild from native Iris screen, auto-selects the Iris tab so users return to the same tab context instead of landing on the first tab.

## Breaking Changes

None